### PR TITLE
Add curl option to Return Transfer

### DIFF
--- a/src/JandjeWebinarJam.php
+++ b/src/JandjeWebinarJam.php
@@ -44,7 +44,7 @@ class JandjeWebinarJam {
             curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
             curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $this->verify_ssl);
             curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);
-
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 
             switch($http_verb) {
                 case 'getallwebinars':


### PR DESCRIPTION
In order to return the results to the curl_exec CURLOPT_RETURNTRANSFER needs to be enabled.